### PR TITLE
fix young makers url

### DIFF
--- a/index.html
+++ b/index.html
@@ -91,7 +91,7 @@
             <h3>
               Support our Young Maker's Robotics teams!
             </h3>
-              <em>Read about their work <a href="http://youngmakers.heatsynclabs.org/welcome/">here</em>.
+              <em>Read about their work <a href="http://youngmakers.heatsynclabs.org/2014/10/15/welcome/">here</em>.
                 <form action="https://www.paypal.com/cgi-bin/webscr" method="post">
                   <input type="hidden" name="cmd" value="_s-xclick" />
                   <input type="hidden" name="hosted_button_id" value="2HVU8J28PWSQ2" />


### PR DESCRIPTION
I changed the format of the urls on the youngmakers site, breaking the link Alisa put on the main page.
