### PR TITLE
remove "robotics teams" wording

### DIFF
--- a/index.html
+++ b/index.html
@@ -86,7 +86,7 @@
           </div>
           <div class="young-makers">
             <h3>
-              Support our Young Makers robotics teams!
+              Support our Young Makers!
             </h3>
               <em>Read about their work <a href="http://youngmakers.heatsynclabs.org/2014/10/15/welcome/">here</em>.
                 <form action="https://www.paypal.com/cgi-bin/webscr" method="post">


### PR DESCRIPTION
Young makers isn't solely focused on robotics teams, and needs funds for other projects.