### PR TITLE
Remove defunct Young Makers links

### DIFF
--- a/index.html
+++ b/index.html
@@ -74,18 +74,6 @@
         	      <img alt="spacer" border="0" src="/img/pixel.gif" width="1" height="1">
         	    </form>
           </div>
-          <div class="young-makers">
-            <h3>
-              Support our Young Makers!
-            </h3>
-              <em><a href="http://youngmakers.heatsynclabs.org/2014/10/15/welcome/">Read about their work.</a></em>
-                <form action="https://www.paypal.com/cgi-bin/webscr" method="post">
-                  <input type="hidden" name="cmd" value="_s-xclick" />
-                  <input type="hidden" name="hosted_button_id" value="2HVU8J28PWSQ2" />
-                  <input type="image" name="submit" src="/img/btn_donate_LG.gif" alt="donate/>
-                  <img src="/img/pixel.gif" alt="" width="1" height="1" border="0" />
-                </form>
-          </div>
         </div>
         <div class="span9">
 		      <div id="main_image">


### PR DESCRIPTION
The Young Makers site is down, and their PayPal link is broken. Removing them (temporarily?)