### PR TITLE
added a page for a fullscreen calendar for the front window

### DIFF
--- a/fscalendar.html
+++ b/fscalendar.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html>
+
+<head>
+    <link rel="manifest" href="manifest.json">
+    <meta name="Description" content="HeatSync Labs. Arizona's greatest hackerspace.">
+    <meta http-equiv="refresh" content="3600" /> 
+    <style type="text/css">
+        body {
+            margin: 0;
+            padding: 0;
+            height: 100%;
+        }
+
+        #wrapper {
+            margin: 0 auto;
+            position: fixed;
+            width: 100%;
+            height: 100%;
+        }
+
+
+    </style>
+    <meta name="theme-color" content="#f99b0c">
+</head>
+
+<body>
+    <div id="wrapper">
+      <iframe src="https://calendar.google.com/calendar/embed?src=heatsynclabs.org_p9rcn09d64q56m7rg07jptmrqc%40group.calendar.google.com&ctz=America%2FPhoenix"  frameborder="0" scrolling="no" width="100%" height="100%" title="calendar entries"></iframe>
+    </div>
+</body>
+
+</html>


### PR DESCRIPTION
Since someone left a couple of large screens in the window, i'm gonna throw a pi or chromebook on one and put the other in the dumpster :)
And since no one is maintaining the physical calendar right now, i'll just display a fullscreen google calendar on a screen.