### PR TITLE
feat(Social Links): Updated YouTube link

### DIFF
--- a/index.html
+++ b/index.html
@@ -50,7 +50,7 @@
           <a href="/"><img src="/img/logo.webp" title="HeatSync Labs" alt="HeatSync Labs"></a>
         </div>
         <div class="social-container span4">
-          <a href="https://www.youtube.com/heatsynclabs" rel="noreferrer" title="YouTube Channel" alt="YouTube Channel" class="social-logo youtube" target="_blank"></a>
+          <a href="https://www.youtube.com/results?search_query=heatsync+labs" rel="noreferrer" title="YouTube Channel" alt="YouTube Channel" class="social-logo youtube" target="_blank"></a>
           <a href="https://www.facebook.com/HeatSyncLabs/" rel="noreferrer" title="Facebook Group" alt="Facebook Group" class="social-logo facebook" target="_blank"></a>
           <a href="https://www.twitter.com/heatsynclabs" rel="noreferrer" title="Twitter" alt="Twitter" class="social-logo twitter" target="_blank"></a>
           <a href="https://www.flickr.com/photos/hslphotosync/" rel="noreferrer" title="HSL PhotoSync" alt="HSL PhotoSync" class="social-logo flickr" target="_blank"></a>


### PR DESCRIPTION
The current YouTube link goes to a 404.  Changed the link, so it goes to
a query results for "Heatsync Labs"