### PR TITLE
Add logo to the classes page, and Membership Footer section

### DIFF
--- a/classes.html
+++ b/classes.html
@@ -36,6 +36,13 @@
 
   </head>
   <body class="register">
+    <div class="container">
+      <div class="row">
+        <div class="span8 logo">
+          <a href="/"><img src="/img/logo.webp" title="HeatSync Labs" alt="HeatSync Labs"></a>
+        </div>
+      </div>
+    </div>
     <div class="container-fluid">
 
         <iframe class="airtable-embed" src="https://airtable.com/embed/shrCG4aqAtGZwVmbk?backgroundColor=purple&viewControls=on" frameborder="0" onmousewheel="" width="100%" height="533" style="background: transparent; border: 1px solid #ccc;"></iframe>

--- a/css/app.css
+++ b/css/app.css
@@ -154,15 +154,24 @@ footer {
 	max-height: 500px;
 }
 
-.register, .classes {
-	overflow: hidden;
+.classes, .register {
+	display: flex;
+	flex-direction: column;
+	height: 100vh;
+	gap: 1rem;
 }
 
-.register .container-fluid, .classes .container-fluid {
-	padding: 0;
+.classes .container-fluid, .register .container-fluid {
+	display: flex;
+	flex-direction: column;
+	align-items: stretch;
+	height: 100%;
 }
-.register iframe, .classes iframe {
-	height: 100vh;
+
+.classes iframe.airtable-embed, .register iframe.airtable-embed {
+	height: 100%;
+	background: transparent;
+	border: 1px solid #ccc;
 }
 
 @media (max-width: 767px) {

--- a/css/app.css
+++ b/css/app.css
@@ -61,11 +61,9 @@ body {
 }
 
 .orange-button, .orange-button:hover{
-	font-color:#000000;
 	background-color: hsl(36, 100%, 53%) !important;
 	background-repeat: repeat-x;
 	filter: progid:DXImageTransform.Microsoft.gradient(startColorstr="#ffc775", endColorstr="#ff9f0f");
-	background-image: -khtml-gradient(linear, left top, left bottom, from(#ffc775), to(#ff9f0f));
 	background-image: -moz-linear-gradient(top, #ffc775, #ff9f0f);
 	background-image: -ms-linear-gradient(top, #ffc775, #ff9f0f);
 	background-image: -webkit-gradient(linear, left top, left bottom, color-stop(0%, #ffc775), color-stop(100%, #ff9f0f));

--- a/index.html
+++ b/index.html
@@ -141,7 +141,7 @@
                 <p>
                   It is a workshop for mad scientists, artists and anyone creating or making! We make tools, resources, and skills available to you.
                 </p>
-                <div class="btn btn-primary btn-large orange-button"><a href="http://members.heatsynclabs.org/">Members' site</a></div>
+                <div class="btn btn-primary btn-large orange-button"><a href="https://members.heatsynclabs.org/">Members' site</a></div>
               </div>
               <div class="span4">
                 <h3>
@@ -151,14 +151,14 @@
                   You don't need to be a member to come and make stuff, but we are member-supported and member-driven so your support is appreciated! We encourage you to bring your projects during public hours so you get a feel for the place first.
                 </p>
                 <p>
-                To learn more about how we work behind the scenes, check out the <a href="http://members.heatsynclabs.org/" style="color: #004460;">Members Website.</a></p>
-                <div class="btn btn-primary btn-large orange-button"><a href="http://members.heatsynclabs.org/">Be a Member</a></div>
+                To learn more about how we work behind the scenes, check out the <a href="https://members.heatsynclabs.org/">Members Website.</a></p>
+                <div class="btn btn-primary btn-large orange-button"><a href="https://members.heatsynclabs.org/users/sign_up">Become a Supporting Member!</a></div>
               </div>
               <div class="span4 hide-link camera-container">
                 <h3>
-                  <a href="live">Live</a>
+                  <a href="/live">Live</a>
                 </h3>
-                <a href="live">
+                <a href="/live">
                   <img src="https://live.heatsynclabs.org/snapshot.php?camera=1" alt="live webcam">
                 </a>
               </div>


### PR DESCRIPTION
The "classes" page did not have the HSL logo on it, so quickly added it.  Can tweak the size and such in a future site refresh.

<img width="1372" alt="Screen Shot 2022-08-12 at 10 17 58 AM" src="https://user-images.githubusercontent.com/105497/184410539-5a067f1a-c14a-4789-a83e-a41644a25df2.png">

<img width="411" alt="Screen Shot 2022-08-12 at 10 58 32 AM" src="https://user-images.githubusercontent.com/105497/184416534-a65b1a7a-350d-4817-8c58-a6e1aa408b19.png">

