### PR TITLE
Add mobile app privacy policy page

### DIFF
--- a/app-privacy-policy.html
+++ b/app-privacy-policy.html
@@ -1,0 +1,208 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>Mobile App Privacy Policy - HeatSync Labs</title>
+    <link rel="manifest" href="manifest.json">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="Description" content="Privacy Policy for HeatSync Labs Mobile App">
+    <meta name="author" content="">
+    <link href="/deps/bootstrap/css/bootstrap.css" rel="stylesheet" type="text/css">
+    <link href="/deps/bootstrap/css/bootstrap-responsive.css" rel="stylesheet" type="text/css">
+    <link href="/deps/Font-Awesome/css/font-awesome.min.css" rel="stylesheet" type="text/css">
+    <script src="https://kit.fontawesome.com/daeb911119.js" crossorigin="anonymous"></script>
+    <link href="/css/app.css" rel="stylesheet" type="text/css">
+    <link href="/css/nav.css" rel="stylesheet" type="text/css">
+    <meta name="theme-color" content="#f99b0c">
+    <meta property="og:url" content="https://heatsynclabs.org/app-privacy-policy.html" />
+
+    <script type="text/javascript">
+      var _gaq = _gaq || [];
+      _gaq.push(['_setAccount', 'UA-12598372-1']);
+      _gaq.push(['_setDomainName', 'heatsynclabs.org']);
+      _gaq.push(['_trackPageview']);
+
+      (function() {
+        var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
+        ga.src = 'https://ssl.google-analytics.com/ga.js';
+        var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
+      })();
+    </script>
+  </head>
+  <body>
+    <nav>
+        <div class="logo">
+          <a href="/"><img src="img/heatsync-labs-logo__white.png" title="HeatSync Labs" alt="HeatSync Labs"></a>
+        </div>
+        <input id="menu-toggle" type="checkbox" />
+        <label class='menu-button-container' for="menu-toggle">
+          <div class='menu-button'></div>
+        </label>
+        <ul class="menu">
+          <li>
+            <a href="classes" title="Classes">Classes</a>
+          </li>
+          <li>
+            <a href="https://members.heatsynclabs.org/" rel="noreferrer" title="Member Site" target="_blank">Membership</a>
+          </li>
+          <li>
+            <a href="https://wiki.heatsynclabs.org/wiki/Main_Page" rel="noreferrer" title="Wiki" target="_blank">Wiki</a>
+          </li>
+          <li>
+            <a href="https://groups.google.com/forum/?fromgroups#!forum/heatsynclabs" alt="HSL Google Group" target="_blank" rel="noreferrer">Discussion Group</a>
+          </li>
+          <li>
+            <a href="https://www.facebook.com/HeatSyncLabs" rel="noreferrer" title="Facebook" target="_blank"><i class="fab fa-facebook"></i></a>
+            <a href="http://heatsynclabs.slack.com" rel="noreferrer" title="Slack" target="_blank"><i class="fab fa-slack"></i></a>
+            <a href="http://www.ebay.com/usr/heatsynclabs" rel="noreferrer" title="eBay" target="_blank"><i class="fab fa-ebay"></i></a>
+            <a href="http://twitter.com/heatsynclabs" rel="noreferrer" title="Twitter" target="_blank"><i class="fab fa-twitter"></i></a>
+            <a href="http://github.com/heatsynclabs" rel="noreferrer" title="GitHub" target="_blank"><i class="fab fa-github"></i></a>
+            <a href="https://www.flickr.com/photos/heatsynclabs" rel="noreferrer" title="Flickr" target="_blank"><i class="fab fa-flickr"></i></a>
+          </li>
+        </ul>
+    </nav>
+
+    <div class="container" style="margin-top: 80px;">
+      <div class="row">
+        <div class="span12">
+          <h1>Privacy Policy for HeatSync Labs Mobile App</h1>
+          <p><strong>Last Updated:</strong> October 7, 2025</p>
+
+          <h2>Introduction</h2>
+          <p>HeatSync Labs ("we," "our," or "us") operates the HeatSync Labs mobile application (the "App"). This Privacy Policy explains how we collect, use, and protect your information when you use our App.</p>
+
+          <h2>Information We Collect</h2>
+
+          <h3>Information You Provide</h3>
+          <ul>
+            <li><strong>Device Registration:</strong> When you enable push notifications, we collect your device token to send you notifications about lab status changes and events.</li>
+            <li><strong>User Preferences:</strong> We store your notification preferences and settings locally on your device.</li>
+          </ul>
+
+          <h3>Automatically Collected Information</h3>
+          <ul>
+            <li><strong>Device Information:</strong> We collect basic device information including device type, operating system version, and app version for troubleshooting and analytics purposes.</li>
+            <li><strong>Usage Data:</strong> We may collect information about how you interact with the App to improve functionality.</li>
+          </ul>
+
+          <h2>How We Use Your Information</h2>
+          <p>We use the collected information to:</p>
+          <ul>
+            <li>Send push notifications about lab door status changes</li>
+            <li>Display lab events from our public Google Calendar</li>
+            <li>Provide real-time lab door status information</li>
+            <li>Improve app functionality and user experience</li>
+            <li>Troubleshoot technical issues</li>
+          </ul>
+
+          <h2>Data Storage and Security</h2>
+          <ul>
+            <li>Device tokens are stored securely in our AWS DynamoDB database</li>
+            <li>Notification preferences are stored locally on your device</li>
+            <li>We implement industry-standard security measures to protect your data</li>
+            <li>We do not sell, trade, or transfer your personal information to third parties</li>
+          </ul>
+
+          <h2>Third-Party Services</h2>
+          <p>Our App uses the following third-party services:</p>
+          <ul>
+            <li><strong>Expo Push Notification Service:</strong> For delivering push notifications</li>
+            <li><strong>Amazon Web Services (AWS):</strong> For backend infrastructure and data storage</li>
+            <li><strong>ConfigCat:</strong> For feature flag management</li>
+            <li><strong>Google Calendar API:</strong> For displaying public lab events (read-only access)</li>
+          </ul>
+          <p>These services may collect information as described in their respective privacy policies.</p>
+
+          <h2>Data Retention</h2>
+          <ul>
+            <li>Device tokens are retained as long as you have the App installed and notifications enabled</li>
+            <li>You can remove your device token by uninstalling the App or disabling notifications in settings</li>
+            <li>Usage data may be retained for up to 90 days for troubleshooting purposes</li>
+          </ul>
+
+          <h2>Your Rights</h2>
+          <p>You have the right to:</p>
+          <ul>
+            <li>Opt out of push notifications at any time through device settings</li>
+            <li>Request deletion of your device token</li>
+            <li>Access information we have collected about you</li>
+            <li>Request correction of any inaccurate information</li>
+          </ul>
+
+          <h2>Children's Privacy</h2>
+          <p>Our App is not directed to children under 13. We do not knowingly collect personal information from children under 13. If you believe we have collected information from a child under 13, please contact us immediately.</p>
+
+          <h2>Changes to This Privacy Policy</h2>
+          <p>We may update this Privacy Policy from time to time. We will notify you of any changes by updating the "Last Updated" date at the top of this policy. We encourage you to review this policy periodically.</p>
+
+          <h2>California Privacy Rights (CCPA)</h2>
+          <p>California residents have specific rights regarding their personal information:</p>
+          <ul>
+            <li>Right to know what personal information is collected</li>
+            <li>Right to know whether personal information is sold or disclosed</li>
+            <li>Right to opt-out of the sale of personal information (we do not sell your information)</li>
+            <li>Right to deletion of personal information</li>
+            <li>Right to non-discrimination for exercising CCPA rights</li>
+          </ul>
+
+          <h2>European Privacy Rights (GDPR)</h2>
+          <p>If you are located in the European Economic Area (EEA), you have certain rights under the General Data Protection Regulation (GDPR):</p>
+          <ul>
+            <li>Right to access your personal data</li>
+            <li>Right to rectification of inaccurate data</li>
+            <li>Right to erasure ("right to be forgotten")</li>
+            <li>Right to restrict processing</li>
+            <li>Right to data portability</li>
+            <li>Right to object to processing</li>
+          </ul>
+
+          <h2>Data We Collect</h2>
+          <table class="table table-bordered" style="margin-top: 20px;">
+            <thead>
+              <tr>
+                <th>Data Category</th>
+                <th>Specific Data</th>
+                <th>Purpose</th>
+                <th>Legal Basis (GDPR)</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>Device Information</td>
+                <td>Device token, OS version, app version</td>
+                <td>Push notifications, troubleshooting</td>
+                <td>Legitimate interest</td>
+              </tr>
+              <tr>
+                <td>Usage Data</td>
+                <td>App interactions, feature usage</td>
+                <td>Improve functionality</td>
+                <td>Legitimate interest</td>
+              </tr>
+              <tr>
+                <td>Preferences</td>
+                <td>Notification settings</td>
+                <td>User experience</td>
+                <td>Consent</td>
+              </tr>
+            </tbody>
+          </table>
+
+          <h2>Contact Us</h2>
+          <p>If you have any questions about this Privacy Policy or our data practices, please contact us at:</p>
+          <p>
+            <strong>HeatSync Labs</strong><br>
+            140 W Main St<br>
+            Mesa, AZ 85201<br>
+            Email: <a href="mailto:operations@heatsynclabs.org">operations@heatsynclabs.org</a>
+          </p>
+
+          <hr style="margin: 40px 0;">
+          <p style="text-align: center;"><a href="/">Return to HeatSync Labs Homepage</a></p>
+        </div>
+      </div>
+    </div>
+
+    <script type="module" src="/src/main.js"></script>
+  </body>
+</html>


### PR DESCRIPTION
Adds a privacy policy page for the HeatSync Labs mobile app at /app-privacy-policy.html

  This privacy policy is required for iOS App Store and Google Play Store submission and covers:
  - Data collection (device tokens, preferences, usage data)
  - Third-party services (Expo, AWS, ConfigCat, Google Calendar)
  - User rights and GDPR/CCPA compliance
  - Contact information

  The page matches the existing site design and navigation.