### PR TITLE
Fix
  privacy policy page build error

### DIFF
--- a/app-privacy-policy.html
+++ b/app-privacy-policy.html
@@ -202,7 +202,5 @@
         </div>
       </div>
     </div>
-
-    <script type="module" src="/src/main.js"></script>
   </body>
 </html>


### PR DESCRIPTION
Removes the /src/main.js script reference that was causing the build to fail. The privacy policy page doesn't need any JavaScript - it's a static content page.