### PR TITLE
Fixed the classes button leading to a 404 when already on classes page

### DIFF
--- a/classes/index.html
+++ b/classes/index.html
@@ -59,7 +59,7 @@
       </label>
       <ul class="menu">
         <li>
-          <a href="classes" title="Classes">Classes</a>
+          <a href="/classes" title="Classes">Classes</a>
         </li>
         <li>
           <a


### PR DESCRIPTION
This is my first ever pull request so apologies if I did this wrong, but here is a small fix (literally a single character addition) to fix the case where when you click on the 'classes' link in the nav bar while already on the classes page, it leads to a 404. I added a `/` so it goes to $home$/classes rather than $home$/classes/classes.
 
Let me know if I could have done this better or if this is an unneeded change, I just wanted to fix a personal peeve I found in the site.