### PR TITLE
Update Google Calendar API key

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -4,6 +4,6 @@ export const config = {
   // They can be safely exposed publicly in client-side code
   // Lives in the heatsynclabsorg project in GCP under the heatsynclabs.org organization
   // Get your API key from https://console.cloud.google.com/
-  googleApiKey: 'AIzaSyAm0-Ssk--CCPoMRmZHtRy9QjNh3ZkGJEk',
+  googleApiKey: 'AIzaSyB_nwLt8AJLtfCXz4BsyG-cl2UV6tL5bes',
   calendarId: 'heatsynclabs.org_p9rcn09d64q56m7rg07jptmrqc@group.calendar.google.com',
 }


### PR DESCRIPTION
Replace old API key with new one that has correct HTTP referrer restrictions for heatsynclabs.org