### PR TITLE
Fix PayPal donate QR code

### DIFF
--- a/src/components/sections/PaymentMethodsSection.astro
+++ b/src/components/sections/PaymentMethodsSection.astro
@@ -53,7 +53,7 @@ const paymentMethods = [
     pros: ['Widely accessible', 'Pay with PayPal balance', 'Buyer protection'],
     cons: ['Fee: 1.99% + $0.49', 'Please cover the fee (checkbox option)'],
     tips: ['If you can, choose to cover the fee — it helps us receive your full donation!'],
-    link: 'https://www.paypal.com/donate?token=CHcahRyHOUjNz5wjbXa6yNOcYC-NDAoe3B_7Kz4fv1rmataOD0O3cW9WIp2IWjlS4m1mvorMP8kqQIUm',
+    link: 'https://www.paypal.com/donate?token=0Bm1iKADYH3rVXc6tJ8F7rV8ArWnT9JoWQ_TzmozNs2Xnio4-gx7Amvg6f6P_RNkbx9NJpgg5SB_gIM1&locale.x=US',
     linkText: 'Pay with PayPal'
   },
   {


### PR DESCRIPTION
The PayPal QR code wasn't working. Now it is.