### PR TITLE
Improve calendar

### DIFF
--- a/src/components/calendar/FullCalendar.vue
+++ b/src/components/calendar/FullCalendar.vue
@@ -151,7 +151,7 @@
           <line x1="8" y1="2" x2="8" y2="6"></line>
           <line x1="3" y1="10" x2="21" y2="10"></line>
         </svg>
-        iCal
+        Add to iCal
       </a>
       <a :href="googleCalendarUrl" target="_blank" rel="noopener noreferrer" class="subscribe-link" title="Add to Google Calendar">
         <svg class="subscribe-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
@@ -161,7 +161,15 @@
           <line x1="3" y1="10" x2="21" y2="10"></line>
           <text x="12" y="18" text-anchor="middle" font-size="7" fill="currentColor" stroke="none" font-weight="bold">G</text>
         </svg>
-        Google Calendar
+        Add to Google Calendar
+      </a>
+      <a :href="googleCalendarEmbedUrl" target="_blank" rel="noopener noreferrer" class="subscribe-link" title="Open in Google Calendar">
+        <svg class="subscribe-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+          <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"></path>
+          <polyline points="15 3 21 3 21 9"></polyline>
+          <line x1="10" y1="14" x2="21" y2="3"></line>
+        </svg>
+        Open in Google Calendar
       </a>
     </div>
 
@@ -197,6 +205,7 @@ import { config } from '../../config'
 const encodedCalendarId = encodeURIComponent(config.calendarId)
 const icalUrl = `https://calendar.google.com/calendar/ical/${encodedCalendarId}/public/basic.ics`
 const googleCalendarUrl = `https://calendar.google.com/calendar/render?cid=${encodedCalendarId}`
+const googleCalendarEmbedUrl = `https://calendar.google.com/calendar/embed?src=${encodedCalendarId}`
 
 // Start with current month, but if we're in the last week, show next month
 const getInitialDate = () => {

--- a/src/components/calendar/FullCalendar.vue
+++ b/src/components/calendar/FullCalendar.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="full-calendar">
     <!-- Recurring Events section -->
-    <div v-if="!loading && recurringEvents.length > 0" class="events-list recurring-section">
+    <div v-if="!loading && recurringEvents.length > 0" class="events-list recurring-section content-constrained">
       <h3 class="events-title">Recurring Events</h3>
       <div class="recurring-events-carousel">
         <div
@@ -26,7 +26,7 @@
       </div>
     </div>
 
-    <div class="calendar-header">
+    <div class="calendar-header content-constrained">
       <div class="header-top-row">
         <div class="view-toggle">
           <button
@@ -52,17 +52,17 @@
       </div>
     </div>
 
-    <div v-if="error" class="calendar-error">
+    <div v-if="error" class="calendar-error content-constrained">
       <p>Unable to load calendar events. Please try again later.</p>
       <button @click="loadEvents" class="nav-button">Retry</button>
     </div>
 
-    <div v-else-if="loading" class="calendar-loading">
+    <div v-else-if="loading" class="calendar-loading content-constrained">
       <p>Loading calendar...</p>
     </div>
 
     <!-- Day View -->
-    <div v-else-if="viewMode === 'day'" class="day-view">
+    <div v-else-if="viewMode === 'day'" class="day-view content-constrained">
       <div v-if="selectedDayEvents.length === 0" class="day-view-empty">
         No events on this day.
       </div>
@@ -97,8 +97,6 @@
     <div
       v-else
       class="calendar-grid"
-      :style="gridStyle"
-      @mouseleave="onGridMouseLeave"
     >
       <!-- Day headers -->
       <div
@@ -118,55 +116,35 @@
           {
             'other-month': !day.isCurrentMonth,
             'today': day.isToday,
-            'has-events': day.events.length > 0,
-            'is-expanded': isExpanded(index),
-            'is-selected': selectedDay && isSameDay(day.date, selectedDay)
+            'has-events': day.events.length > 0
           }
         ]"
-        @mouseenter="onDayMouseEnter(index)"
-        @mouseleave="onDayMouseLeave"
         @click="onDayClick(day)"
       >
         <div class="day-number">{{ day.date.getDate() }}</div>
         <div v-if="day.events.length > 0" class="day-events">
-          <template v-if="isExpanded(index)">
-            <div
-              v-for="event in day.events"
-              :key="event.id"
-              :class="[
-                'event-dot',
-                { 'all-day': event.isAllDay }
-              ]"
-              :title="`${event.title} - ${formatEventTime(event)}`"
-              @click.stop="openEventModal(event)"
-            >
-              <span class="event-time-inline">{{ formatEventTimeShort(event) }}</span>
-              <span class="event-title">{{ event.displayTitle }}</span>
-            </div>
-          </template>
-          <template v-else>
-            <div
-              v-for="event in day.events.slice(0, 3)"
-              :key="event.id"
-              :class="[
-                'event-dot',
-                { 'all-day': event.isAllDay }
-              ]"
-              :title="`${event.title} - ${formatEventTime(event)}`"
-              @click.stop="openEventModal(event)"
-            >
-              <span class="event-title">{{ getTruncatedTitle(event.title) }}</span>
-            </div>
-            <div v-if="day.events.length > 3" class="more-events" @click.stop="onDayClick(day)">
-              +{{ day.events.length - 3 }} more
-            </div>
-          </template>
+          <div
+            v-for="event in day.events.slice(0, 3)"
+            :key="event.id"
+            :class="[
+              'event-dot',
+              { 'all-day': event.isAllDay }
+            ]"
+            :title="`${event.title} - ${formatEventTime(event)}`"
+            @click.stop="openEventModal(event)"
+          >
+            <span class="event-time-inline">{{ formatEventTimeShort(event) }}</span>
+            <span class="event-title">{{ event.title }}</span>
+          </div>
+          <div v-if="day.events.length > 3" class="more-events" @click.stop="onDayClick(day)">
+            +{{ day.events.length - 3 }} more
+          </div>
         </div>
       </div>
     </div>
 
     <!-- One-time Events section -->
-    <div v-if="!loading && oneTimeEvents.length > 0" class="events-list">
+    <div v-if="!loading && oneTimeEvents.length > 0" class="events-list content-constrained">
       <h3 class="events-title">Upcoming Events</h3>
       <div class="events-grid">
         <EventCard
@@ -187,7 +165,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, onMounted, onUnmounted } from 'vue'
+import { ref, computed, onMounted } from 'vue'
 import { format, startOfMonth, endOfMonth, startOfWeek, endOfWeek, eachDayOfInterval, isSameDay, isSameMonth, addMonths, subMonths, addDays, subDays, isToday, startOfDay, endOfDay } from 'date-fns'
 import EventCard from '../events/EventCard.vue'
 import EventModal from '../events/EventModal.vue'
@@ -210,12 +188,9 @@ const error = ref(false)
 const modalVisible = ref(false)
 const selectedEvent = ref<CalendarEvent | null>(null)
 
-// View mode and expansion state
+// View mode
 const viewMode = ref<'month' | 'day'>('month')
-const hoveredCol = ref<number | null>(null)
-const hoveredRow = ref<number | null>(null)
 const selectedDay = ref<Date | null>(null)
-const isMobile = ref(typeof window !== 'undefined' ? window.innerWidth <= 768 : false)
 
 const calendarService = new CalendarService()
 
@@ -242,99 +217,9 @@ const calendarDays = computed(() => {
   }))
 })
 
-// Number of rows in current calendar grid
-const rowCount = computed(() => Math.ceil(calendarDays.value.length / 7))
-
-// Which col/row is active (selected takes priority over hover)
-const activeCol = computed(() => {
-  if (isMobile.value) return null
-  if (selectedDay.value) {
-    const idx = calendarDays.value.findIndex(d => isSameDay(d.date, selectedDay.value!))
-    if (idx >= 0) return idx % 7
-  }
-  return hoveredCol.value
-})
-
-const activeRow = computed(() => {
-  if (isMobile.value) return null
-  if (selectedDay.value) {
-    const idx = calendarDays.value.findIndex(d => isSameDay(d.date, selectedDay.value!))
-    if (idx >= 0) return Math.floor(idx / 7)
-  }
-  return hoveredRow.value
-})
-
-// Grid template styles for expansion effect
-const gridStyle = computed(() => {
-  const col = activeCol.value
-  const row = activeRow.value
-
-  if (col === null || row === null) {
-    return {}
-  }
-
-  const cols = Array(7).fill('0.83fr')
-  cols[col] = '2fr'
-
-  const rows = Array(rowCount.value).fill('0.83fr')
-  rows[row] = '2fr'
-
-  return {
-    gridTemplateColumns: cols.join(' '),
-    gridTemplateRows: `auto ${rows.join(' ')}`
-  }
-})
-
-const isExpanded = (index: number) => {
-  const col = index % 7
-  const row = Math.floor(index / 7)
-  return activeCol.value === col && activeRow.value === row
-}
-
-const dayNeedsExpansion = (day: { events: CalendarEvent[] }) => {
-  if (day.events.length > 3) return true
-  const maxLen = typeof window !== 'undefined' && window.innerWidth <= 768 ? 10 : 15
-  return day.events.some(e => e.title.length > maxLen)
-}
-
-let hoverTimer: ReturnType<typeof setTimeout> | null = null
-
-const onDayMouseEnter = (index: number) => {
-  if (isMobile.value || selectedDay.value) return
-  const day = calendarDays.value[index]
-  if (!day || !dayNeedsExpansion(day)) return
-  if (hoverTimer) clearTimeout(hoverTimer)
-  hoverTimer = setTimeout(() => {
-    hoveredCol.value = index % 7
-    hoveredRow.value = Math.floor(index / 7)
-  }, 500)
-}
-
-const onDayMouseLeave = () => {
-  if (hoverTimer) { clearTimeout(hoverTimer); hoverTimer = null }
-}
-
-const onGridMouseLeave = () => {
-  if (hoverTimer) { clearTimeout(hoverTimer); hoverTimer = null }
-  if (selectedDay.value) return
-  hoveredCol.value = null
-  hoveredRow.value = null
-}
-
 const onDayClick = (day: { date: Date; events: CalendarEvent[] }) => {
-  if (isMobile.value) {
-    // Mobile: tap a day -> switch to day view
-    selectedDay.value = day.date
-    viewMode.value = 'day'
-    return
-  }
-
-  // Desktop: click to pin/unpin expansion
-  if (selectedDay.value && isSameDay(selectedDay.value, day.date)) {
-    selectedDay.value = null
-  } else {
-    selectedDay.value = day.date
-  }
+  selectedDay.value = day.date
+  viewMode.value = 'day'
 }
 
 // Day view events
@@ -463,7 +348,7 @@ const formatEventTime = (event: CalendarEvent) => {
 
 const formatEventTimeShort = (event: CalendarEvent) => {
   if (event.isAllDay) return 'All Day'
-  return format(event.start, 'h:mma').toLowerCase()
+  return `${format(event.start, 'h:mma').toLowerCase()}-${format(event.end, 'h:mma').toLowerCase()}`
 }
 
 const previousMonth = () => {
@@ -514,24 +399,21 @@ const closeEventModal = () => {
   selectedEvent.value = null
 }
 
-const onResize = () => {
-  isMobile.value = window.innerWidth <= 768
-}
-
 onMounted(() => {
   loadEvents()
-  window.addEventListener('resize', onResize)
-})
-
-onUnmounted(() => {
-  window.removeEventListener('resize', onResize)
 })
 </script>
 
 <style scoped>
 .full-calendar {
-  max-width: 1200px;
+  max-width: 100%;
   margin: 0 auto;
+}
+
+.content-constrained {
+  max-width: var(--container-xl);
+  margin-left: auto;
+  margin-right: auto;
 }
 
 .calendar-header {
@@ -627,7 +509,6 @@ onUnmounted(() => {
   border-radius: var(--radius-base);
   overflow: hidden;
   margin-bottom: var(--space-12);
-  transition: grid-template-columns 0.3s ease, grid-template-rows 0.3s ease;
 }
 
 .day-header {
@@ -649,7 +530,6 @@ onUnmounted(() => {
   flex-direction: column;
   position: relative;
   cursor: pointer;
-  transition: min-height 0.3s ease;
   overflow: hidden;
 }
 
@@ -660,15 +540,6 @@ onUnmounted(() => {
 
 .calendar-day.today {
   background: rgba(168, 90, 60, 0.1);
-}
-
-.calendar-day.is-selected {
-  box-shadow: inset 0 0 0 2px var(--color-accent-primary);
-  background: rgba(168, 90, 60, 0.05);
-}
-
-.calendar-day.is-expanded {
-  overflow-y: auto;
 }
 
 .calendar-day.today .day-number {
@@ -721,10 +592,6 @@ onUnmounted(() => {
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-}
-
-.is-expanded .event-title {
-  white-space: normal;
 }
 
 .event-time-inline {
@@ -1013,6 +880,10 @@ onUnmounted(() => {
   .event-dot {
     padding: 1px var(--space-1);
     font-size: 10px;
+  }
+
+  .event-time-inline {
+    display: none;
   }
 
   .event-title {

--- a/src/components/calendar/FullCalendar.vue
+++ b/src/components/calendar/FullCalendar.vue
@@ -143,6 +143,28 @@
       </div>
     </div>
 
+    <div v-if="!loading" class="subscribe-links content-constrained">
+      <a :href="icalUrl" class="subscribe-link" title="Subscribe via iCal">
+        <svg class="subscribe-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+          <rect x="3" y="4" width="18" height="18" rx="2" ry="2"></rect>
+          <line x1="16" y1="2" x2="16" y2="6"></line>
+          <line x1="8" y1="2" x2="8" y2="6"></line>
+          <line x1="3" y1="10" x2="21" y2="10"></line>
+        </svg>
+        iCal
+      </a>
+      <a :href="googleCalendarUrl" target="_blank" rel="noopener noreferrer" class="subscribe-link" title="Add to Google Calendar">
+        <svg class="subscribe-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+          <rect x="3" y="4" width="18" height="18" rx="2" ry="2"></rect>
+          <line x1="16" y1="2" x2="16" y2="6"></line>
+          <line x1="8" y1="2" x2="8" y2="6"></line>
+          <line x1="3" y1="10" x2="21" y2="10"></line>
+          <text x="12" y="18" text-anchor="middle" font-size="7" fill="currentColor" stroke="none" font-weight="bold">G</text>
+        </svg>
+        Google Calendar
+      </a>
+    </div>
+
     <!-- One-time Events section -->
     <div v-if="!loading && oneTimeEvents.length > 0" class="events-list content-constrained">
       <h3 class="events-title">Upcoming Events</h3>
@@ -170,6 +192,11 @@ import { format, startOfMonth, endOfMonth, startOfWeek, endOfWeek, eachDayOfInte
 import EventCard from '../events/EventCard.vue'
 import EventModal from '../events/EventModal.vue'
 import { CalendarService, type CalendarEvent } from '../../services/calendarService'
+import { config } from '../../config'
+
+const encodedCalendarId = encodeURIComponent(config.calendarId)
+const icalUrl = `https://calendar.google.com/calendar/ical/${encodedCalendarId}/public/basic.ics`
+const googleCalendarUrl = `https://calendar.google.com/calendar/render?cid=${encodedCalendarId}`
 
 // Start with current month, but if we're in the last week, show next month
 const getInitialDate = () => {
@@ -430,6 +457,40 @@ onMounted(() => {
   justify-content: center;
 }
 
+.subscribe-links {
+  display: flex;
+  justify-content: center;
+  gap: var(--space-1);
+  padding: var(--space-1) 0;
+}
+
+.subscribe-link {
+  display: flex;
+  align-items: center;
+  gap: var(--space-1);
+  padding: var(--space-1) var(--space-3);
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  color: var(--color-text-secondary);
+  text-decoration: none;
+  border: 1px solid var(--color-text-tertiary);
+  border-radius: var(--radius-base);
+  background: var(--color-bg-secondary);
+  transition: all var(--transition-base);
+}
+
+.subscribe-link:hover {
+  background: var(--color-accent-primary);
+  color: var(--color-bg-primary);
+  border-color: var(--color-accent-primary);
+}
+
+.subscribe-icon {
+  width: 14px;
+  height: 14px;
+  flex-shrink: 0;
+}
+
 .header-nav-row {
   display: flex;
   align-items: center;
@@ -508,7 +569,7 @@ onMounted(() => {
   background: var(--color-text-tertiary);
   border-radius: var(--radius-base);
   overflow: hidden;
-  margin-bottom: var(--space-12);
+  margin-bottom: var(--space-2);
 }
 
 .day-header {
@@ -616,7 +677,7 @@ onMounted(() => {
 
 /* Day View */
 .day-view {
-  margin-bottom: var(--space-12);
+  margin-bottom: var(--space-2);
   display: flex;
   flex-direction: column;
   gap: var(--space-3);
@@ -964,6 +1025,11 @@ onMounted(() => {
   .view-toggle-btn {
     padding: var(--space-1) var(--space-2);
     font-size: 10px;
+  }
+
+  .subscribe-link {
+    font-size: 10px;
+    padding: var(--space-1) var(--space-2);
   }
 
   .calendar-grid {

--- a/src/components/events/EventModal.vue
+++ b/src/components/events/EventModal.vue
@@ -177,13 +177,15 @@ const formatEventTime = (event: CalendarEvent): string => {
 }
 
 .event-registration--link {
+  color: var(--color-accent-primary);
+  background: rgba(168, 90, 60, 0.1);
   text-decoration: none;
   cursor: pointer;
   transition: background var(--transition-base), color var(--transition-base);
 }
 
 .event-registration--link:hover {
-  background: rgba(104, 127, 93, 0.2);
+  background: rgba(168, 90, 60, 0.2);
   color: var(--color-text-primary);
 }
 
@@ -197,6 +199,10 @@ const formatEventTime = (event: CalendarEvent): string => {
   color: var(--accent-sage);
   flex-shrink: 0;
   transition: color var(--transition-base);
+}
+
+.event-registration--link .registration-icon {
+  color: var(--color-accent-primary);
 }
 
 .event-meta {
@@ -240,6 +246,23 @@ const formatEventTime = (event: CalendarEvent): string => {
   font-size: var(--text-base);
   color: var(--color-text-secondary);
   line-height: var(--leading-relaxed);
+  font-family: var(--font-sans);
+}
+
+.event-description div :deep(br) {
+  display: block;
+  content: '';
+  margin-top: var(--space-3);
+}
+
+.event-description div :deep(a) {
+  color: var(--color-accent-primary);
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+.event-description div :deep(a:hover) {
+  color: var(--color-text-primary);
 }
 
 /* Responsive */

--- a/src/components/sections/CalendarSection.vue
+++ b/src/components/sections/CalendarSection.vue
@@ -16,7 +16,7 @@
       </div>
 
       <div v-else class="calendar__events">
-        <div class="events-carousel">
+        <div class="events-grid">
           <EventCard
             v-for="event in events"
             :key="event.id"
@@ -43,26 +43,38 @@
 </template>
 
 <script setup lang="ts">
-import { ref, onMounted } from 'vue'
+import { ref, computed, onMounted, onUnmounted } from 'vue'
 import BaseContainer from '../base/BaseContainer.vue'
 import BaseButton from '../base/BaseButton.vue'
 import EventCard from '../events/EventCard.vue'
 import EventModal from '../events/EventModal.vue'
 import { CalendarService, type CalendarEvent } from '../../services/calendarService'
 
-const events = ref<CalendarEvent[]>([])
+const allEvents = ref<CalendarEvent[]>([])
 const loading = ref(true)
 const error = ref(false)
 const modalVisible = ref(false)
 const selectedEvent = ref<CalendarEvent | null>(null)
+const isMobile = ref(typeof window !== 'undefined' ? window.innerWidth <= 768 : false)
 
 const calendarService = new CalendarService()
+
+const events = computed(() => {
+  if (isMobile.value) {
+    return allEvents.value.slice(0, 3)
+  }
+  return allEvents.value
+})
+
+const onResize = () => {
+  isMobile.value = window.innerWidth <= 768
+}
 
 const loadEvents = async () => {
   try {
     loading.value = true
     error.value = false
-    events.value = await calendarService.getEvents(14) // Next 2 weeks for upcoming events
+    allEvents.value = await calendarService.getEvents(14) // Next 2 weeks for upcoming events
   } catch (err) {
     console.error('Failed to load calendar events:', err)
     error.value = true
@@ -84,6 +96,11 @@ const closeEventModal = () => {
 
 onMounted(() => {
   loadEvents()
+  window.addEventListener('resize', onResize)
+})
+
+onUnmounted(() => {
+  window.removeEventListener('resize', onResize)
 })
 </script>
 
@@ -115,7 +132,7 @@ onMounted(() => {
   margin: 0 auto;
 }
 
-.events-carousel {
+.events-grid {
   display: flex;
   gap: var(--space-4);
   overflow-x: auto;
@@ -123,26 +140,26 @@ onMounted(() => {
   scroll-behavior: smooth;
 }
 
-.events-carousel::-webkit-scrollbar {
+.events-grid :deep(.event-card) {
+  flex: 0 0 300px;
+}
+
+.events-grid::-webkit-scrollbar {
   height: 8px;
 }
 
-.events-carousel::-webkit-scrollbar-track {
+.events-grid::-webkit-scrollbar-track {
   background: var(--warm-gray);
   border-radius: var(--radius-full);
 }
 
-.events-carousel::-webkit-scrollbar-thumb {
+.events-grid::-webkit-scrollbar-thumb {
   background: var(--accent-rust);
   border-radius: var(--radius-full);
 }
 
-.events-carousel::-webkit-scrollbar-thumb:hover {
+.events-grid::-webkit-scrollbar-thumb:hover {
   background: var(--accent-sage);
-}
-
-.events-carousel .event-card {
-  flex: 0 0 280px;
 }
 
 .calendar__footer {
@@ -158,14 +175,16 @@ onMounted(() => {
     padding: var(--space-12) 0;
   }
 
-  .calendar__event {
+  .events-grid {
+    display: flex;
     flex-direction: column;
-    text-align: center;
+    overflow-x: visible;
+    padding: 0;
   }
 
-  .event__date {
-    align-self: center;
-    margin-bottom: var(--space-3);
+  .events-grid :deep(.event-card) {
+    flex: none;
+    width: 100%;
   }
 }
 </style>

--- a/src/pages/calendar.astro
+++ b/src/pages/calendar.astro
@@ -8,7 +8,7 @@ import FullCalendar from '../components/calendar/FullCalendar.vue';
 
 <Layout title="Calendar - HeatSync Labs">
   <div class="calendar-page">
-    <BaseContainer>
+    <BaseContainer size="full">
       <FullCalendar client:load />
     </BaseContainer>
   </div>

--- a/src/services/calendarService.ts
+++ b/src/services/calendarService.ts
@@ -294,9 +294,8 @@ export class CalendarService {
       .replace(/\(?Registration\s*Required\)?:?\s*/gi, '')
       .replace(/https?:\/\/guestli(?:\.st|st\.co)\/[^\s<>"')]+/gi, '')
       .replace(/\(?\$\d+(?:\.\d{2})?\)?:?\s*/g, '')
-      .replace(/<br\s*\/?>/gi, ' ')
-      .replace(/\n+/g, ' ')
-      .replace(/\s+/g, ' ')
+      .replace(/\n/g, '<br>')
+      .replace(/(<br\s*\/?>)+/gi, '<br>')
       .trim()
 
     return {


### PR DESCRIPTION
- Registration links now use rust to better indicate they are active (this was causing some confusion)
- Event descriptions preserve links and whitespace (this was causing some confusion)

<img width="633" height="743" alt="image" src="https://github.com/user-attachments/assets/2af6d161-00ec-4782-a657-3c8951af3b5f" />

- On the homepage, events now scroll vertically instead of horizontally on mobile (this was causing some confusion)
<img width="508" height="744" alt="image" src="https://github.com/user-attachments/assets/6f746de2-4362-4718-a6a7-46a51ec96a30" />

- Expanded the calendar view to take up the entire screen width on desktop and show the times for events (requested feature)
<img width="1906" height="1208" alt="image" src="https://github.com/user-attachments/assets/a96236e7-f8e3-4dbf-a2f6-2350679ec902" />

- Added iCal and Google Calendar links (requested feature)
<img width="574" height="98" alt="image" src="https://github.com/user-attachments/assets/1d4bde55-1685-4ed5-993b-1355b3b504fd" />

