### PR TITLE
Restore app-privacy-policy.html to public/ directory

### DIFF
--- a/public/app-privacy-policy.html
+++ b/public/app-privacy-policy.html
@@ -1,0 +1,331 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>Mobile App Privacy Policy - HeatSync Labs</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Privacy Policy for HeatSync Labs Mobile App">
+    <meta name="theme-color" content="#d35f35">
+    <meta property="og:url" content="https://heatsynclabs.org/app-privacy-policy.html">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Charis+SIL:ital,wght@0,400;0,700;1,400;1,700&display=swap" rel="stylesheet">
+    <style>
+      *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+      body {
+        font-family: 'Charis SIL', Georgia, serif;
+        font-size: 16px;
+        line-height: 1.7;
+        color: #1a1918;
+        background: #f9f7f5;
+      }
+
+      /* Header */
+      header {
+        background: #1a1918;
+        padding: 0 24px;
+        height: 64px;
+        display: flex;
+        align-items: center;
+      }
+
+      header a {
+        display: flex;
+        align-items: center;
+        text-decoration: none;
+      }
+
+      header img {
+        height: 36px;
+        width: auto;
+      }
+
+      /* Main content */
+      main {
+        max-width: 780px;
+        margin: 0 auto;
+        padding: 56px 24px 80px;
+      }
+
+      h1 {
+        font-size: 28px;
+        font-weight: 700;
+        line-height: 1.2;
+        color: #1a1918;
+        margin-bottom: 8px;
+      }
+
+      .last-updated {
+        font-size: 14px;
+        color: #6b6866;
+        margin-bottom: 40px;
+        padding-bottom: 24px;
+        border-bottom: 1px solid rgba(107, 104, 102, 0.3);
+      }
+
+      h2 {
+        font-size: 20px;
+        font-weight: 700;
+        color: #1a1918;
+        margin-top: 36px;
+        margin-bottom: 12px;
+      }
+
+      h3 {
+        font-size: 17px;
+        font-weight: 700;
+        color: #3e3d3c;
+        margin-top: 24px;
+        margin-bottom: 8px;
+      }
+
+      p {
+        margin-bottom: 14px;
+        color: #3e3d3c;
+      }
+
+      ul {
+        margin: 0 0 14px 0;
+        padding-left: 24px;
+        color: #3e3d3c;
+      }
+
+      ul li {
+        margin-bottom: 6px;
+      }
+
+      a {
+        color: #d35f35;
+        text-decoration: underline;
+        text-underline-offset: 2px;
+      }
+
+      a:hover {
+        color: #b84d28;
+      }
+
+      /* Table */
+      .table-wrapper {
+        overflow-x: auto;
+        margin: 16px 0 24px;
+        border-radius: 6px;
+        border: 1px solid rgba(107, 104, 102, 0.3);
+      }
+
+      table {
+        width: 100%;
+        border-collapse: collapse;
+        font-size: 14px;
+      }
+
+      thead {
+        background: #1a1918;
+        color: #f9f7f5;
+      }
+
+      thead th {
+        padding: 12px 16px;
+        text-align: left;
+        font-weight: 600;
+        letter-spacing: 0.3px;
+      }
+
+      tbody tr:nth-child(odd) {
+        background: #fefcfa;
+      }
+
+      tbody tr:nth-child(even) {
+        background: #f3f1ef;
+      }
+
+      tbody td {
+        padding: 11px 16px;
+        vertical-align: top;
+        border-top: 1px solid rgba(107, 104, 102, 0.15);
+        color: #3e3d3c;
+      }
+
+      /* Divider */
+      hr {
+        border: none;
+        border-top: 1px solid rgba(107, 104, 102, 0.3);
+        margin: 48px 0 32px;
+      }
+
+      /* Footer */
+      footer {
+        text-align: center;
+        margin-top: 0;
+      }
+
+      footer a {
+        display: inline-block;
+        padding: 10px 24px;
+        background: #d35f35;
+        color: #f9f7f5;
+        text-decoration: none;
+        border-radius: 4px;
+        font-size: 15px;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+        transition: background 0.15s ease;
+      }
+
+      footer a:hover {
+        background: #b84d28;
+        color: #f9f7f5;
+      }
+
+      @media (max-width: 600px) {
+        main { padding: 40px 16px 60px; }
+        h1 { font-size: 24px; }
+      }
+    </style>
+  </head>
+  <body>
+    <header>
+      <a href="/"><img src="/hsl-logo.png" alt="HeatSync Labs"></a>
+    </header>
+
+    <main>
+      <h1>Privacy Policy for HeatSync Labs Mobile App</h1>
+      <p class="last-updated"><strong>Last Updated:</strong> October 7, 2025</p>
+
+      <h2>Introduction</h2>
+      <p>HeatSync Labs ("we," "our," or "us") operates the HeatSync Labs mobile application (the "App"). This Privacy Policy explains how we collect, use, and protect your information when you use our App.</p>
+
+      <h2>Information We Collect</h2>
+
+      <h3>Information You Provide</h3>
+      <ul>
+        <li><strong>Device Registration:</strong> When you enable push notifications, we collect your device token to send you notifications about lab status changes and events.</li>
+        <li><strong>User Preferences:</strong> We store your notification preferences and settings locally on your device.</li>
+      </ul>
+
+      <h3>Automatically Collected Information</h3>
+      <ul>
+        <li><strong>Device Information:</strong> We collect basic device information including device type, operating system version, and app version for troubleshooting and analytics purposes.</li>
+        <li><strong>Usage Data:</strong> We may collect information about how you interact with the App to improve functionality.</li>
+      </ul>
+
+      <h2>How We Use Your Information</h2>
+      <p>We use the collected information to:</p>
+      <ul>
+        <li>Send push notifications about lab door status changes</li>
+        <li>Display lab events from our public Google Calendar</li>
+        <li>Provide real-time lab door status information</li>
+        <li>Improve app functionality and user experience</li>
+        <li>Troubleshoot technical issues</li>
+      </ul>
+
+      <h2>Data Storage and Security</h2>
+      <ul>
+        <li>Device tokens are stored securely in our AWS DynamoDB database</li>
+        <li>Notification preferences are stored locally on your device</li>
+        <li>We implement industry-standard security measures to protect your data</li>
+        <li>We do not sell, trade, or transfer your personal information to third parties</li>
+      </ul>
+
+      <h2>Third-Party Services</h2>
+      <p>Our App uses the following third-party services:</p>
+      <ul>
+        <li><strong>Expo Push Notification Service:</strong> For delivering push notifications</li>
+        <li><strong>Amazon Web Services (AWS):</strong> For backend infrastructure and data storage</li>
+        <li><strong>ConfigCat:</strong> For feature flag management</li>
+        <li><strong>Google Calendar API:</strong> For displaying public lab events (read-only access)</li>
+      </ul>
+      <p>These services may collect information as described in their respective privacy policies.</p>
+
+      <h2>Data Retention</h2>
+      <ul>
+        <li>Device tokens are retained as long as you have the App installed and notifications enabled</li>
+        <li>You can remove your device token by uninstalling the App or disabling notifications in settings</li>
+        <li>Usage data may be retained for up to 90 days for troubleshooting purposes</li>
+      </ul>
+
+      <h2>Your Rights</h2>
+      <p>You have the right to:</p>
+      <ul>
+        <li>Opt out of push notifications at any time through device settings</li>
+        <li>Request deletion of your device token</li>
+        <li>Access information we have collected about you</li>
+        <li>Request correction of any inaccurate information</li>
+      </ul>
+
+      <h2>Children's Privacy</h2>
+      <p>Our App is not directed to children under 13. We do not knowingly collect personal information from children under 13. If you believe we have collected information from a child under 13, please contact us immediately.</p>
+
+      <h2>Changes to This Privacy Policy</h2>
+      <p>We may update this Privacy Policy from time to time. We will notify you of any changes by updating the "Last Updated" date at the top of this policy. We encourage you to review this policy periodically.</p>
+
+      <h2>California Privacy Rights (CCPA)</h2>
+      <p>California residents have specific rights regarding their personal information:</p>
+      <ul>
+        <li>Right to know what personal information is collected</li>
+        <li>Right to know whether personal information is sold or disclosed</li>
+        <li>Right to opt-out of the sale of personal information (we do not sell your information)</li>
+        <li>Right to deletion of personal information</li>
+        <li>Right to non-discrimination for exercising CCPA rights</li>
+      </ul>
+
+      <h2>European Privacy Rights (GDPR)</h2>
+      <p>If you are located in the European Economic Area (EEA), you have certain rights under the General Data Protection Regulation (GDPR):</p>
+      <ul>
+        <li>Right to access your personal data</li>
+        <li>Right to rectification of inaccurate data</li>
+        <li>Right to erasure ("right to be forgotten")</li>
+        <li>Right to restrict processing</li>
+        <li>Right to data portability</li>
+        <li>Right to object to processing</li>
+      </ul>
+
+      <h2>Data We Collect</h2>
+      <div class="table-wrapper">
+        <table>
+          <thead>
+            <tr>
+              <th>Data Category</th>
+              <th>Specific Data</th>
+              <th>Purpose</th>
+              <th>Legal Basis (GDPR)</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>Device Information</td>
+              <td>Device token, OS version, app version</td>
+              <td>Push notifications, troubleshooting</td>
+              <td>Legitimate interest</td>
+            </tr>
+            <tr>
+              <td>Usage Data</td>
+              <td>App interactions, feature usage</td>
+              <td>Improve functionality</td>
+              <td>Legitimate interest</td>
+            </tr>
+            <tr>
+              <td>Preferences</td>
+              <td>Notification settings</td>
+              <td>User experience</td>
+              <td>Consent</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+
+      <h2>Contact Us</h2>
+      <p>If you have any questions about this Privacy Policy or our data practices, please contact us at:</p>
+      <p>
+        <strong>HeatSync Labs</strong><br>
+        140 W Main St<br>
+        Mesa, AZ 85201<br>
+        Email: <a href="mailto:operations@heatsynclabs.org">operations@heatsynclabs.org</a>
+      </p>
+
+      <hr>
+      <footer>
+        <a href="/">Return to HeatSync Labs Homepage</a>
+      </footer>
+    </main>
+  </body>
+</html>


### PR DESCRIPTION
The file was removed in commit 52c4e1d when the site was migrated from static HTML to Vue.js. Placing it in public/ ensures Vite copies it to the build output root, making it accessible at /app-privacy-policy.html.