### PR TITLE
Swap Special Elite/VT323 for Instrument Sans/Space Mono in central theme

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -31,7 +31,7 @@ const { title = 'HeatSync Labs' } = Astro.props;
     </script>
     <meta name="generator" content={Astro.generator} />
 
-    <!-- Fonts are imported in tokens.css (Permanent Marker / Special Elite / VT323 / Courier Prime / Charis SIL) -->
+    <!-- Fonts are imported in tokens.css (Permanent Marker / Instrument Sans / Space Mono / Courier Prime / Charis SIL) -->
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
 
@@ -61,7 +61,7 @@ const { title = 'HeatSync Labs' } = Astro.props;
     flex-direction: column;
     background-color: var(--color-bg-primary);
     color: var(--color-text-primary);
-    line-height: 1.6;
+    line-height: 1.62;
     position: relative;
     transition: background-color var(--transition-base), color var(--transition-base);
   }

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -28,7 +28,7 @@ body {
   transition: background-color var(--transition-base), color var(--transition-base);
 }
 
-/* Headings: Special Elite by default. Permanent Marker is applied
+/* Headings: Instrument Sans by default. Permanent Marker is applied
    only to big display titles via .display-title / per-component. */
 h1, h2, h3, h4, h5, h6 {
   font-family: var(--font-body);
@@ -45,7 +45,7 @@ h1, h2, h3, h4, h5, h6 {
   text-shadow: none;
 }
 
-/* UI / label voice - VT323 */
+/* UI / label voice - Space Mono */
 .ui-text,
 .eyebrow {
   font-family: var(--font-ui);

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -7,7 +7,7 @@
    ============================================================ */
 
 /* Design system fonts. Charis SIL stays as the LOGO BRAND FONT only. */
-@import url('https://fonts.googleapis.com/css2?family=Permanent+Marker&family=Special+Elite&family=VT323&family=Courier+Prime:wght@400;700&family=Charis+SIL:ital,wght@0,400;0,700;1,400;1,700&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Permanent+Marker&family=Instrument+Sans:wght@400;500;600;700&family=Space+Mono:wght@400;700&family=Courier+Prime:wght@400;700&family=Charis+SIL:ital,wght@0,400;0,700;1,400;1,700&display=swap');
 
 :root {
   /* ---- Raw palette (design system canon) ---- */
@@ -121,12 +121,12 @@
 
   /* ---- Typography ---- */
   --font-display: 'Permanent Marker', cursive;   /* big headlines only */
-  --font-body:    'Special Elite', Georgia, serif; /* body copy */
-  --font-ui:      'VT323', monospace;             /* eyebrows, labels, nav, stats */
+  --font-body:    'Instrument Sans', sans-serif; /* body copy */
+  --font-ui:      'Space Mono', monospace;       /* eyebrows, labels, nav, stats */
   --font-mono:    'Courier Prime', 'SF Mono', monospace; /* fine print, code */
   --font-logo:    'Charis SIL', Georgia, serif;   /* LOGO WORDMARK ONLY - brand font */
 
-  /* Back-compat aliases: body text -> Special Elite, serif -> logo brand font */
+  /* Back-compat aliases: body text -> Instrument Sans, serif -> logo brand font */
   --font-sans:    var(--font-body);
   --font-serif:   var(--font-logo);
 
@@ -160,7 +160,7 @@
   /* Line Heights */
   --leading-tight: 1.05;
   --leading-normal: 1.5;
-  --leading-relaxed: 1.55;
+  --leading-relaxed: 1.62;
   --leading-loose: 1.7;
 
   /* Spacing Scale */


### PR DESCRIPTION
## Summary
- Replaces body font (Special Elite → Instrument Sans) and UI/label font (VT323 → Space Mono) in `tokens.css`, including the Google Fonts `@import`.
- Bumps body line-height 1.55 → 1.62 via `--leading-relaxed` to match the design-system v3 spec.
- Updates the matching comments in `tokens.css`, `base.css`, and `Layout.astro`.
- Permanent Marker, Courier Prime, and Charis SIL (logo wordmark) are unchanged. Colors, shadows, ramp sizes, and tracking tokens are untouched.

Source of truth: local `heatsync-design-system (3).html` spec. Component-level UI-label resizing (e.g. `.eyebrow` at 22px → 14px / 0.18em / 700) is intentionally **not** in this PR — it's component scope, not central-theme tokens. Happy to do that as a follow-up.

## Test plan
- [x] `npm run build` — clean, all 10 routes render
- [ ] Visual spot-check on `gh-pages` preview after merge: hero, body copy, eyebrows/labels, calendar chips, buttons
- [ ] Confirm new Google Fonts request loads Instrument Sans + Space Mono (network tab)

🤖 Generated with [Claude Code](https://claude.com/claude-code)