### PR TITLE
Lab status: show next calendar event when closed (not only Open Hours)

### DIFF
--- a/src/components/layout/LabStatusIndicator.vue
+++ b/src/components/layout/LabStatusIndicator.vue
@@ -26,18 +26,14 @@ const displayText = computed(() => {
   if (isLoading.value) return 'Checking...'
   if (isOpen.value) return 'OPEN'
 
-  // When closed, show next opening time if available
+  // When closed, show the next thing on the calendar (any timed event, not just Open Hours)
   const now = new Date()
-  const upcomingOpenHours = events.value
-    .filter(event => {
-      const eventStart = new Date(event.start)
-      const eventTitle = event.title.toLowerCase()
-      return eventStart > now && eventTitle.includes('open hours')
-    })
-    .sort((a, b) => new Date(a.start).getTime() - new Date(b.start).getTime())
+  const nextEvent = events.value.find(event =>
+    !event.isAllDay && new Date(event.start) > now
+  )
 
-  if (upcomingOpenHours.length > 0) {
-    const nextOpen = new Date(upcomingOpenHours[0].start)
+  if (nextEvent) {
+    const nextOpen = new Date(nextEvent.start)
     const day = format(nextOpen, 'EEE')
     const time = format(nextOpen, 'ha').toLowerCase()
     return `Closed • Opens ${day} ${time}`


### PR DESCRIPTION
## Summary
- `LabStatusIndicator` previously filtered upcoming events to titles containing "open hours" to render `Closed • Opens <day> <time>`. Classes, workshops, and other timed events were ignored — so the badge would jump to a generic `CLOSED` even when something was about to happen on the calendar in a couple of hours.
- Now any timed (non-all-day) future event qualifies. The list from `calendarService.getAllEvents()` is already sorted, so a single `find` replaces the prior `filter + sort + [0]`.
- All-day events are skipped — "Opens Tue 12am" for a Maker Faire-type all-day item isn't useful.
- Wording unchanged: still `Closed • Opens <day> <time>`. No event name added (kept it compact for the badge).

## Test plan
- [x] `npm run build` clean, all 10 routes render
- [ ] Visual: when door API reports closed and there is a non-Open-Hours timed event next (e.g. a class), badge shows `Closed • Opens <day> <time>` pointing at it
- [ ] Visual: if the next thing on the calendar is an all-day event, badge falls back to `CLOSED` (or to a later timed event)
- [ ] Visual: when no future timed event exists within the 7-day window, badge shows `CLOSED`

🤖 Generated with [Claude Code](https://claude.com/claude-code)